### PR TITLE
pep8 conformity and fixing broken nosetests

### DIFF
--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -51,6 +51,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from xdesign.geometry import *
 from xdesign.geometry import beamcirc
+from xdesign.acquisition import *
 from numpy.testing import assert_allclose, assert_raises
 import numpy as np
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,8 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# #########################################################################
+# Copyright (c) 2016, UChicago Argonne, LLC. All rights reserved.         #
+#                                                                         #
+# Copyright 2015. UChicago Argonne, LLC. This software was produced       #
+# under U.S. Government contract DE-AC02-06CH11357 for Argonne National   #
+# Laboratory (ANL), which is operated by UChicago Argonne, LLC for the    #
+# U.S. Department of Energy. The U.S. Government has rights to use,       #
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR    #
+# UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR        #
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is     #
+# modified to produce derivative works, such modified software should     #
+# be clearly marked, so as not to confuse it with the version available   #
+# from ANL.                                                               #
+#                                                                         #
+# Additionally, redistribution and use in source and binary forms, with   #
+# or without modification, are permitted provided that the following      #
+# conditions are met:                                                     #
+#                                                                         #
+#     * Redistributions of source code must retain the above copyright    #
+#       notice, this list of conditions and the following disclaimer.     #
+#                                                                         #
+#     * Redistributions in binary form must reproduce the above copyright #
+#       notice, this list of conditions and the following disclaimer in   #
+#       the documentation and/or other materials provided with the        #
+#       distribution.                                                     #
+#                                                                         #
+#     * Neither the name of UChicago Argonne, LLC, Argonne National       #
+#       Laboratory, ANL, the U.S. Government, nor the names of its        #
+#       contributors may be used to endorse or promote products derived   #
+#       from this software without specific prior written permission.     #
+#                                                                         #
+# THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS     #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT       #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago     #
+# Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,        #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    #
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;        #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER        #
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT      #
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN       #
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
+# POSSIBILITY OF SUCH DAMAGE.                                             #
+# #########################################################################
+
 from xdesign.phantom import *
 from xdesign.material import *
 from numpy.testing import assert_allclose, assert_raises, assert_equal
 import numpy as np
 import scipy
+
+__author__ = "Daniel Ching"
+__copyright__ = "Copyright (c) 2016, UChicago Argonne, LLC."
+__docformat__ = 'restructuredtext en'
+
 
 def test_HyperbolicCocentric():
     p0 = Phantom()
@@ -13,10 +66,12 @@ def test_HyperbolicCocentric():
     p = HyperbolicConcentric()
     target = p.discrete(200, uniform=False)
 
-    assert_equal(target, ref, "Default HyperbolicConcentric phantom has changed.")
+    assert_equal(target, ref,
+                 "Default HyperbolicConcentric phantom has changed.")
+
 
 def test_DynamicRange():
-    for i in range(0,2):
+    for i in range(0, 2):
         p0 = Phantom()
         p0.load('tests/DynamicRange'+str(i)+'.txt')
         ref = p0.discrete(100)
@@ -25,7 +80,9 @@ def test_DynamicRange():
         p = DynamicRange(jitter=i)
         target = p.discrete(100)
 
-        assert_equal(target, ref, "Default DynamicRange" + str(i)+ " phantom has changed.")
+        assert_equal(target, ref, "Default DynamicRange" + str(i) +
+                                  " phantom has changed.")
+
 
 def test_Soil():
     p0 = Phantom()
@@ -37,6 +94,7 @@ def test_Soil():
     target = p.discrete(100)
 
     assert_equal(target, ref, "Default Soil phantom has changed.")
+
 
 def test_Foam():
     p0 = Phantom()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,41 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# #########################################################################
+# Copyright (c) 2016, UChicago Argonne, LLC. All rights reserved.         #
+#                                                                         #
+# Copyright 2015. UChicago Argonne, LLC. This software was produced       #
+# under U.S. Government contract DE-AC02-06CH11357 for Argonne National   #
+# Laboratory (ANL), which is operated by UChicago Argonne, LLC for the    #
+# U.S. Department of Energy. The U.S. Government has rights to use,       #
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR    #
+# UChicago Argonne, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR        #
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is     #
+# modified to produce derivative works, such modified software should     #
+# be clearly marked, so as not to confuse it with the version available   #
+# from ANL.                                                               #
+#                                                                         #
+# Additionally, redistribution and use in source and binary forms, with   #
+# or without modification, are permitted provided that the following      #
+# conditions are met:                                                     #
+#                                                                         #
+#     * Redistributions of source code must retain the above copyright    #
+#       notice, this list of conditions and the following disclaimer.     #
+#                                                                         #
+#     * Redistributions in binary form must reproduce the above copyright #
+#       notice, this list of conditions and the following disclaimer in   #
+#       the documentation and/or other materials provided with the        #
+#       distribution.                                                     #
+#                                                                         #
+#     * Neither the name of UChicago Argonne, LLC, Argonne National       #
+#       Laboratory, ANL, the U.S. Government, nor the names of its        #
+#       contributors may be used to endorse or promote products derived   #
+#       from this software without specific prior written permission.     #
+#                                                                         #
+# THIS SOFTWARE IS PROVIDED BY UChicago Argonne, LLC AND CONTRIBUTORS     #
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT       #
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS       #
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL UChicago     #
+# Argonne, LLC OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,        #
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,    #
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;        #
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER        #
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT      #
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN       #
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE         #
+# POSSIBILITY OF SUCH DAMAGE.                                             #
+# #########################################################################
+
 from xdesign.plot import plot_metrics
-from xdesign.metrics import _compute_ssim, _compute_vifp, _compute_fsim, compute_quality, ImageQuality
+from xdesign.metrics import (_compute_ssim, _compute_vifp, _compute_fsim,
+                             compute_quality, ImageQuality)
 from numpy.testing import *
 import numpy as np
 import scipy
 
 
-# SSIM metric
+__author__ = "Daniel Ching"
+__copyright__ = "Copyright (c) 2016, UChicago Argonne, LLC."
+__docformat__ = 'restructuredtext en'
+
 
 def test_SSIM_same_image_is_unity():
     img1 = scipy.ndimage.imread("tests/cameraman.png")
-    IQ = ImageQuality(img1,img1)
+    IQ = ImageQuality(img1, img1)
     IQ = _compute_ssim(IQ)
-    assert_equal(IQ.qualities[0],1,err_msg="Mean is not unity.")
-    assert_equal(IQ.maps[0],np.ones(img1.shape),err_msg="local metrics are not unity.")
-    assert_equal(img1.shape,IQ.maps[0].shape,err_msg="SSIMs map not the same size as input")
+    assert_equal(IQ.qualities[0], 1, err_msg="Mean is not unity.")
+    assert_equal(IQ.maps[0], np.ones(img1.shape),
+                 err_msg="local metrics are not unity.")
+    assert_equal(img1.shape, IQ.maps[0].shape,
+                 err_msg="SSIMs map not the same size as input")
+
 
 def test_VIFp_same_image_is_unity():
     img1 = scipy.ndimage.imread("tests/cameraman.png")
-    IQ = ImageQuality(img1,img1)
+    IQ = ImageQuality(img1, img1)
     IQ = _compute_vifp(IQ)
-    assert_almost_equal(IQ.qualities,1,err_msg="Mean is not unity.")
-    #assert_equal(IQ.maps,1,err_msg="local metrics are not unity.")
+    assert_almost_equal(IQ.qualities, 1, err_msg="Mean is not unity.")
+    # assert_equal(IQ.maps,1,err_msg="local metrics are not unity.")
+
 
 def test_FSIM_same_image_is_unity():
     img1 = scipy.ndimage.imread("tests/cameraman.png")
-    IQ = ImageQuality(img1,img1)
+    IQ = ImageQuality(img1, img1)
     IQ = _compute_fsim(IQ)
-    assert_almost_equal(IQ.qualities,1.,err_msg="Mean is not unity.")
-    #assert_almost_equal(IQ.maps,np.ones(len(IQ.maps)),err_msg="local metrics are not unity.")
+    assert_almost_equal(IQ.qualities, 1., err_msg="Mean is not unity.")
+    # assert_almost_equal(IQ.maps, np.ones(len(IQ.maps)),
+    #                     err_msg="local metrics are not unity.")
+
 
 def test_compute_quality_cameraman():
-    img1 = scipy.ndimage.imread("tests/cameraman.png") # original
+    img1 = scipy.ndimage.imread("tests/cameraman.png")  # original
     img4 = scipy.ndimage.imread("tests/cameraman_mixed1.png")
-    # salt and pepper, gaussian noise, square? smoothing filter, guassian filter
-    metrics = compute_quality(img1,[img4],method="VIFp", L=256)
-    #plot_metrics(metrics)
-    metrics = compute_quality(img1,[img4],method="FSIM", L=256)
-    #plot_metrics(metrics)
-    metrics = compute_quality(img1,[img4],method="MSSSIM", L=256)
-    #plot_metrics(metrics)
+
+    metrics = compute_quality(img1, [img4], method="VIFp", L=256)
+    # plot_metrics(metrics)
+    metrics = compute_quality(img1, [img4], method="FSIM", L=256)
+    # plot_metrics(metrics)
+    metrics = compute_quality(img1, [img4], method="MSSSIM", L=256)
+    # plot_metrics(metrics)

--- a/xdesign/acquisition.py
+++ b/xdesign/acquisition.py
@@ -135,7 +135,7 @@ def sinogram(sx, sy, phantom, noise=False):
     scan = raster_scan(sx, sy)
     sino = np.zeros((sx, sy))
     for m in range(sx):
-        print (m)
+        print(m)
         for n in range(sy):
             sino[m, n] = next(scan).measure(phantom, noise)
     return sino
@@ -160,7 +160,7 @@ def angleogram(sx, sy, phantom, noise=False):
     scan = angle_scan(sx, sy)
     angl = np.zeros((sx, sy))
     for m in range(sx):
-        print (m)
+        print(m)
         for n in range(sy):
             angl[m, n] = next(scan).measure(phantom, noise)
     return angl

--- a/xdesign/geometry.py
+++ b/xdesign/geometry.py
@@ -504,12 +504,14 @@ class Circle(Ellipse):
         self.radius = float(radius)
 
     def __eq__(self, circle):
-        return (self.x, self.y, self.radius) == (circle.x, circle.y, circle.radius)
+        return (self.x, self.y, self.radius) == (circle.x, circle.y,
+                                                 circle.radius)
 
     @property
     def equation(self):
         """Return analytical equation."""
-        return "(x-%s)^2 + (y-%s)^2 = %s^2" % (self.center.x, self.center.y, self.radius)
+        return "(x-%s)^2 + (y-%s)^2 = %s^2" % (self.center.x, self.center.y,
+                                               self.radius)
 
     @property
     def list(self):

--- a/xdesign/material.py
+++ b/xdesign/material.py
@@ -102,7 +102,8 @@ class Material(object):
 
     @property
     def reduced_energy_ratio(self, energy):
-        """Energy ratio of the incident x-ray and the electron energy [Unitless]."""
+        """Energy ratio of the incident x-ray and the electron energy
+        [Unitless]."""
         raise NotImplementedError
 
     @property
@@ -138,8 +139,8 @@ class Material(object):
 
 class HyperbolicConcentric(Phantom):
     """Generates a series of cocentric alternating black and white circles whose
-    radii are changing at a parabolic rate. These lines whose spacing covers a
-    range scales can be used to estimate the Modulation Transfer Function (MTF).
+    radii are changing at a parabolic rate. These line spacings cover a range
+    of scales and can be used to estimate the Modulation Transfer Function.
     """
 
     def __init__(self, min_width=0.1, exponent=1 / 2):
@@ -153,7 +154,7 @@ class HyperbolicConcentric(Phantom):
         """
         super(HyperbolicConcentric, self).__init__(shape='circle')
         center = Point(0.5, 0.5)
-        #exponent = 1/2
+        # exponent = 1/2
         Nmax_rings = 512
 
         radii = [0]
@@ -214,7 +215,8 @@ class DynamicRange(Phantom):
         else:
             # completely random
             for i in range(0, steps):
-                if 1 > self.sprinkle(1, radius, gap=radius * 0.9, value=colors[i]):
+                if 1 > self.sprinkle(1, radius, gap=radius * 0.9,
+                                     value=colors[i]):
                     None
                     # TODO: ensure that all circles are placed
 

--- a/xdesign/phantom.py
+++ b/xdesign/phantom.py
@@ -49,11 +49,11 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from xdesign.geometry import *
 import numpy as np
 import scipy.ndimage
 import logging
 import warnings
-from xdesign.geometry import *
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class Phantom(object):
     @property
     def list(self):
         for m in range(self.population):
-            print (self.feature[m].list)
+            print(self.feature[m].list)
 
     @property
     def density(self):
@@ -131,9 +131,9 @@ class Phantom(object):
     def sort(self, param="value", reverse=False):
         """Sorts the features by value or size"""
         if param == "value":
-            key = lambda circle: circle.value
+            def key(circle): return circle.value
         elif param == "size":
-            key = lambda circle: circle.area
+            def key(circle): return circle.area
         else:
             warnings.warn("Can't sort by " + param)
             return
@@ -143,7 +143,8 @@ class Phantom(object):
         """Reverse the features of the phantom"""
         self.feature.reverse()
 
-    def sprinkle(self, counts, radius, gap=0, region=None, value=1, max_density=1):
+    def sprinkle(self, counts, radius, gap=0, region=None, value=1,
+                 max_density=1):
         """Sprinkle a number of circles.
 
         Parameters
@@ -176,14 +177,15 @@ class Phantom(object):
             raise NotImplementedError
 
         collision = False
-        if radius[0] + gap < 0:  # prevents defining circles with negative radius
+        if radius[0] + gap < 0:  # prevents circles with negative radius
             collision = True
 
-        kTERM_CRIT = 200  # how many tries to append a new circle before quitting
-        n_tries = 0  # number of attempts to append a new circle
-        n_added = 0  # number of circles successfully added
+        kTERM_CRIT = 200  # tries to append a new circle before quitting
+        n_tries = 0  # attempts to append a new circle
+        n_added = 0  # circles successfully added
 
-        while n_tries < kTERM_CRIT and n_added < counts and self.density < max_density:
+        while (n_tries < kTERM_CRIT and n_added < counts and
+               self.density < max_density):
             center = self._random_point(radius[0], region=region)
 
             if collision:
@@ -252,8 +254,8 @@ class Phantom(object):
         ratio : scalar, optional
             The discretization works by supersampling. This parameter controls
             how many pixels in the larger representation are averaged for the
-            final representation. e.g. if ratio = 8, then the final pixel values
-            are the average of 64 pixels.
+            final representation. e.g. if ratio = 8, then the final pixel
+            values are the average of 64 pixels.
         uniform : boolean, optional
             When set to False, changes the way pixels are averaged from a
             uniform weights to gaussian weights.
@@ -263,7 +265,7 @@ class Phantom(object):
         image : numpy.ndarray
             The discrete representation of the phantom.
         """
-        #error = 1./ratio**2
+        # error = 1./ratio**2
         # warnings.warn("Discrete conversion is approximate. " +
         #              "True values will be within " + str(error) + " %")
 


### PR DESCRIPTION
Fixing broken nosetests for geometry class was as easy as adding an import statement for the acquisition module. Also added license notice headers and fixed pep 8 stuff.