### PR TITLE
BLD: Make setuptools_scm store version number for archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival  export-subst

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     name='xdesign',
     packages=find_packages('src'),
     package_dir={"": "src"},
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
     use_scm_version=True,
     author='Daniel Ching, Doga Gursoy',
     description='Benchmarking and optimization tools for tomography.',


### PR DESCRIPTION
Without these files, setup will fail for archives of the
the respository that do not have git installed. e.g. anyone
who downloads the source without git or the conda-forge
feedstock